### PR TITLE
added missing license meta file giving error on import

### DIFF
--- a/LICENSE.txt.meta
+++ b/LICENSE.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 298ef97df07d4c14982d6f5a0ca32688
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
generated missing meta file giving errors on package import:

![image](https://github.com/Netherlands3D/Json-Extras/assets/11850024/1f238006-854e-41b3-a376-da32bb052ad2)
